### PR TITLE
Created reuseable Image display component

### DIFF
--- a/components/imageDisplay.tsx
+++ b/components/imageDisplay.tsx
@@ -12,7 +12,7 @@ export default function ImageDisplay({ src, alt, width, height, caption }: Image
   return (
     <div className="max-w-sm rounded overflow-hidden shadow-lg">
       <div className="relative" style={{ width: `${width}px`, height: `${height}px` }}>
-        <Image src={src || "/placeholder.svg"} alt={alt} layout="fill" objectFit="cover" />
+        <Image src={src || "/placeholder.svg"} alt={alt} fill style = {{ objectFit: "cover" }} />
       </div>
       {caption && (
         <div className="px-6 py-4">

--- a/components/imageDisplay.tsx
+++ b/components/imageDisplay.tsx
@@ -1,0 +1,27 @@
+import Image from "next/image"
+
+interface ImageDisplayProps {
+  src: string
+  alt: string
+  width: number
+  height: number
+  caption?: string
+}
+
+export default function ImageDisplay({ src, alt, width, height, caption }: ImageDisplayProps) {
+  return (
+    <div className="max-w-sm rounded overflow-hidden shadow-lg">
+      <div className="relative" style={{ width: `${width}px`, height: `${height}px` }}>
+        <Image src={src || "/placeholder.svg"} alt={alt} layout="fill" objectFit="cover" />
+      </div>
+      {caption && (
+        <div className="px-6 py-4">
+          <p className="text-gray-700 text-base">{caption}</p>
+        </div>
+      )}
+    </div>
+  )
+}
+
+
+


### PR DESCRIPTION
Fixes # - Image Display Component

This PR introduces an `ImageDisplay` component to be used across the project. The component takes in image details such as source, alt text, width, height, and an optional caption. It is designed to work seamlessly with the `Next.js` `Image` component, offering optimized loading of images with dynamic sizing.

Changes made:
- created a reuseable `ImageDisplay` component that renders images with a responsive layout and optional captions.

Why was it changed:
The goal of this change was to create a reusable component for displaying images that can be utilized across the project, enhancing maintainability and allowing for responsive behavior. This will make it easier to manage images in the future.

How was it changed:
- Created the `ImageDisplay` component, ensuring it receives necessary props (`src`, `alt`, `width`, `height`, and `caption`) and renders them properly.
- Incorporated `next/image` for optimized image loading with `layout="intrinsic"` for dynamic sizing.
- Implemented a container for the image, with support for optional captions displayed underneath the image.
- Tested the component with a demo image gallery.
![Screenshot 2025-02-03 005059](https://github.com/user-attachments/assets/84512f48-11f5-47c5-a510-90608cefb3a4)
