### PR TITLE
Added a Navigation Bar at the bottom with Buttons

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,8 +4,6 @@ import CameraButton from "@/components/cameraButton";
 export default function Home() {
   return (
     <div className="flex items-center justify-center h-screen relative">
-      <div className="absolute top-4 left-4 w-8 h-8 bg-gray-300 rounded"></div>
-
       <div className="flex flex-col items-center">
         <main className="w-80 h-80 border-2 border-gray-300 rounded-lg overflow-hidden shadow-lg flex items-center justify-center bg-black-100">
           <Image

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -24,6 +24,20 @@ export default function Home() {
           <CameraButton />
         </div>
       </div>
+      <nav className="absolute bottom-0 w-full bg-white border-t flex justify-around py-2 shadow-md">
+        <button className="flex flex-col items-center text-gray-700">
+          <div className="w-6 h-6 bg-gray-500 rounded-full"></div>
+          <span className="text-xs">Home</span>
+        </button>
+        <button className="flex flex-col items-center text-gray-700">
+          <div className="w-6 h-6 bg-gray-500 rounded-full"></div>
+          <span className="text-xs">Search</span>
+        </button>
+        <button className="flex flex-col items-center text-gray-700">
+          <div className="w-6 h-6 bg-gray-500 rounded-full"></div>
+          <span className="text-xs">Profile</span>
+        </button>
+      </nav>
     </div>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import CameraButton from "@/components/cameraButton";
+import NavigationBar from "@/components/navigationBar"
 
 export default function Home() {
   return (
@@ -22,20 +23,7 @@ export default function Home() {
           <CameraButton />
         </div>
       </div>
-      <nav className="absolute bottom-0 w-full bg-white border-t flex justify-around py-2 shadow-md">
-        <button className="flex flex-col items-center text-gray-700">
-          <div className="w-6 h-6 bg-gray-500 rounded-full"></div>
-          <span className="text-xs">Home</span>
-        </button>
-        <button className="flex flex-col items-center text-gray-700">
-          <div className="w-6 h-6 bg-gray-500 rounded-full"></div>
-          <span className="text-xs">Search</span>
-        </button>
-        <button className="flex flex-col items-center text-gray-700">
-          <div className="w-6 h-6 bg-gray-500 rounded-full"></div>
-          <span className="text-xs">Profile</span>
-        </button>
-      </nav>
+      <NavigationBar/>
     </div>
   );
 }

--- a/components/navigationBar.tsx
+++ b/components/navigationBar.tsx
@@ -1,0 +1,21 @@
+const BottomNav = () => {
+    return (
+      <nav className="absolute bottom-0 w-full bg-white border-t flex justify-around py-2 shadow-md">
+        <button className="flex flex-col items-center text-gray-700">
+          <div className="w-6 h-6 bg-gray-500 rounded-full"></div>
+          <span className="text-xs">Home</span>
+        </button>
+        <button className="flex flex-col items-center text-gray-700">
+          <div className="w-6 h-6 bg-gray-500 rounded-full"></div>
+          <span className="text-xs">Search</span>
+        </button>
+        <button className="flex flex-col items-center text-gray-700">
+          <div className="w-6 h-6 bg-gray-500 rounded-full"></div>
+          <span className="text-xs">Profile</span>
+        </button>
+      </nav>
+    );
+  };
+  
+  export default BottomNav;
+  


### PR DESCRIPTION
Fixes #13 

What was changed?
Modified the Home Page Layout to add a navigation bar at the bottom of the page with three buttons which act as a placeholder for now. Also, the navigation button on the top left was deleted which was no longer needed.

Why was it changed?
Initially we were gonna implement a navigation bar on the top left but eventually the end goal of this project is to create a mobile application framework. So we decided to go with the traditional navigation bar for the mobile applications which is usually at the bottom of the screen with bunch of buttons.

How was it changed?
For this, code was added to the page.tsx file in app folder. First, a navigation bar space was created in the bottom of the page and then three button were added which for now acts as placeholders. For removing the top left, the code for that was just deleted. 


Before the Changes, Home Page:
<img width="1439" alt="Screenshot 2025-02-17 at 2 25 46 PM" src="https://github.com/user-attachments/assets/c0e8edff-eef8-45f5-8460-0d3c7bb51b68" />

After the Changes, Home Page:
<img width="1439" alt="Screenshot 2025-02-17 at 2 22 13 PM" src="https://github.com/user-attachments/assets/94358100-3afc-40e5-87a7-cb675fbb593a" />

Mobile View of Home Page after Changes:
<img width="413" alt="Screenshot 2025-02-17 at 2 39 12 PM" src="https://github.com/user-attachments/assets/1ec254f5-ca71-4fcd-af7e-061c53b91f12" />