### PR TITLE
Expansion Modal Component Creation

### DIFF
--- a/app/components/imageModal.tsx
+++ b/app/components/imageModal.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+interface ImageModalProps {
+  image: {
+    id: string;
+    data: string;
+    timestamp: string;
+  };
+  onClose: () => void;
+}
+
+export default function ImageModal({ image, onClose }: ImageModalProps) {
+  return (
+    <div
+      className="fixed inset-0 bg-black bg-opacity-60 flex justify-center items-center z-50"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white rounded-lg p-4 max-w-md mx-auto"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <img src={image.data} alt="Expanded" className="rounded-md mb-4" />
+        <div className="text-sm text-gray-700">
+          <p><strong>ID:</strong> {image.id}</p>
+          <p><strong>Timestamp:</strong> {new Date(image.timestamp).toLocaleString()}</p>
+        </div>
+        <button
+          className="mt-4 px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
+          onClick={onClose}
+        >
+          Close
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
fixes #45 

---

**Description**:

This PR introduces a new `ImageModal` component that provides the basic structure for displaying an expanded view of an image alongside optional metadata.

---

**What was changed**:

- Created a reusable `ImageModal` component in the `components/` directory.
- The component accepts the following props:
  - `image`: an object containing `id`, `data` (image source), and `timestamp`.
  - `onClose`: a function to close the modal.
- Built a simple modal layout using TailwindCSS:
  - Displays the image enlarged.
  - Shows metadata (ID and Timestamp).
  - Includes a Close button to trigger the `onClose` callback.
- Basic modal styling added (centered on screen, background dimming).

---

**Why was it changed**:

- To establish a reusable, lightweight modal component for future use across pages where image expansion is needed.
- To improve user experience by enabling full-screen previews of images.
- To prepare for upcoming features like clicking images in the gallery to expand them.

---

**How was it changed**:

- Used TailwindCSS for modal layout and responsiveness.
- Ensured that clicking outside the modal background or pressing Close calls the `onClose` prop.
- Encapsulated all modal logic inside a dedicated component (`ImageModal.tsx`) for separation of concerns and easier testing.

---

> **Note**: The `ImageModal` has been created but **has not yet been integrated** into the `page.tsx` or wired to any click events. 

